### PR TITLE
Add in-browser challenge terminal and fix challenge upload / SSH user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@ DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=postgres_db
 
-HOST_URL=https://atlas.webclub.nitk.ac.in
-DOCKER_HOST_URL=https://1.2.3.4 # Replace with your actual Docker host URL
-KEY_FILE_PATH=/app/id_rsa
+HOST_URL=http://localhost
+SSH_HOST_URL=localhost
+DOCKER_HOST_URL=unix://var/run/docker.sock
+KEY_FILE_PATH=
 
 # # PgAdmin
 # PGADMIN_DEFAULT_EMAIL=admin@admin.com

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,14 @@ DB_PASSWORD=postgres
 DB_NAME=postgres_db
 
 HOST_URL=http://localhost
+# Public host shown to players for published-port (service) challenges.
+# (Name kept for backwards compatibility; terminal challenges use docker exec.)
 SSH_HOST_URL=localhost
 DOCKER_HOST_URL=unix://var/run/docker.sock
 KEY_FILE_PATH=
+# Internal docker network for terminal challenge containers: no host exposure,
+# no outbound internet. Must match the challenge-net "name:" in docker-compose.yml.
+CHALLENGE_NETWORK=atlas-challenges
 
 # # PgAdmin
 # PGADMIN_DEFAULT_EMAIL=admin@admin.com

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 .pnpm-store/
 .npm/
 
+my-challenge.tar
+
 # Build outputs
 dist/
 dist-ssr/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,16 @@
+# Keep build-time and local-only cruft out of the image.
+__pycache__/
+*.py[cod]
+*.egg-info
+.venv
+venv
+env
+.env
+*.sqlite3
+.git
+.gitignore
+.dockerignore
+Dockerfile
+.DS_Store
+.vscode
+.idea

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,6 @@ COPY . .
 # Expose port
 EXPOSE 8000
 
-# Run the backend server
+# Run the backend server (daphne serves both HTTP and WebSocket via ASGI)
 ENTRYPOINT [ "/app/code/entrypoint.sh" ]
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "backend.asgi:application"]

--- a/backend/atlas_backend/consumers.py
+++ b/backend/atlas_backend/consumers.py
@@ -1,0 +1,173 @@
+"""WebSocket terminal proxy backed by ``docker exec``.
+
+Bridges a browser WebSocket (xterm.js) to an interactive shell inside the
+team's challenge container via ``docker exec`` over the Docker Engine API —
+no SSH, no published ports, no daemon inside the challenge container. The
+exec stream travels over the docker socket the backend already mounts, so the
+challenge container needs no network reachability at all for the terminal.
+
+Wire protocol (mirrored in frontend/src/components/ChallengeTerminal.jsx):
+  - binary frames carry raw terminal bytes in both directions
+  - text frames carry JSON control messages, e.g.
+    {"type": "resize", "cols": 120, "rows": 32}
+
+Close codes sent to the browser:
+  - 4401 not authenticated / not in a team
+  - 4403 team is banned
+  - 4404 no running container for this challenge (or not a shell challenge)
+  - 4502 could not exec into the container
+"""
+
+import asyncio
+import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
+from django.conf import settings
+
+from docker_plugin import DockerPlugin
+
+from .models import Container
+
+logger = logging.getLogger('atlas_backend')
+
+EXEC_READ_CHUNK = 32 * 1024
+
+# Dedicated pool for blocking docker-exec socket I/O. Every live terminal parks
+# one worker in a blocking recv(), so max_workers effectively caps concurrent
+# terminal sessions (the asyncio default executor would cap them lower and
+# starve other work).
+EXEC_IO_EXECUTOR = ThreadPoolExecutor(
+    max_workers=int(os.getenv("TERMINAL_MAX_SESSIONS", "100")),
+    thread_name_prefix="exec-io",
+)
+
+
+class TerminalConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.plugin = None
+        self.exec_id = None
+        self.sock = None
+        self.reader_task = None
+
+        # Accept before validating so the browser receives our close codes;
+        # a pre-accept close surfaces as an opaque handshake failure.
+        await self.accept()
+
+        user = self.scope.get("user")
+        if user is None or not user.team:  # team preloaded via select_related
+            await self.close(code=4401)
+            return
+        if user.team.is_banned:
+            await self.close(code=4403)
+            return
+
+        challenge_id = self.scope["url_route"]["kwargs"]["challenge_id"]
+        container = await self._get_container(user.team, challenge_id)
+        # ssh_user is the unprivileged shell user to exec as; its presence is
+        # what marks a challenge as a terminal (vs. published-port) challenge.
+        if container is None or not container.ssh_user:
+            await self.close(code=4404)
+            return
+
+        self.container_id = container.container_id
+        self.exec_user = container.ssh_user
+        self.team_name = user.team.name
+
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(EXEC_IO_EXECUTOR, self._open_exec)
+        except Exception:
+            logger.exception(
+                "Terminal proxy could not exec into container %s for team %s",
+                self.container_id[:12], self.team_name,
+            )
+            await self.close(code=4502)
+            return
+
+        self.reader_task = asyncio.create_task(self._pump_exec_to_ws())
+
+    @database_sync_to_async
+    def _get_container(self, team, challenge_id):
+        return (
+            Container.objects.filter(team=team, challenge_id=challenge_id)
+            .order_by("-created_at")
+            .first()
+        )
+
+    def _open_exec(self):
+        """Blocking; runs in EXEC_IO_EXECUTOR."""
+        self.plugin = DockerPlugin(
+            base_url=settings.DOCKER_HOST, key_file=settings.SSH_KEY_FILE
+        )
+        self.exec_id, self.sock = self.plugin.start_exec(
+            self.container_id, user=self.exec_user
+        )
+
+    async def _pump_exec_to_ws(self):
+        """Forward exec output to the WebSocket until EOF or teardown."""
+        loop = asyncio.get_running_loop()
+        sock = self.sock
+        try:
+            while True:
+                data = await loop.run_in_executor(
+                    EXEC_IO_EXECUTOR, sock.recv, EXEC_READ_CHUNK
+                )
+                if not data:
+                    break
+                await self.send(bytes_data=data)
+        except Exception:
+            # Socket torn down (client left, container stopped, ...)
+            pass
+        finally:
+            try:
+                await self.close()
+            except Exception:
+                pass
+
+    async def receive(self, text_data=None, bytes_data=None):
+        if self.sock is None:
+            return
+        try:
+            if bytes_data:
+                # Keystrokes are tiny; sendall to the local docker socket
+                # won't meaningfully block the event loop.
+                self.sock.sendall(bytes_data)
+            elif text_data:
+                message = json.loads(text_data)
+                if message.get("type") == "resize":
+                    rows = max(1, int(message.get("rows", 24)))
+                    cols = max(1, int(message.get("cols", 80)))
+                    loop = asyncio.get_running_loop()
+                    # exec_resize is an HTTP call to the daemon; keep it off
+                    # the event loop thread.
+                    await loop.run_in_executor(
+                        EXEC_IO_EXECUTOR,
+                        self.plugin.resize_exec,
+                        self.exec_id,
+                        rows,
+                        cols,
+                    )
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass  # malformed control message; ignore
+        except OSError:
+            await self.close()
+
+    async def disconnect(self, code):
+        reader = self.reader_task
+        sock = self.sock
+        self.reader_task = None
+        self.sock = None
+
+        # Closing the socket unblocks the recv() parked in the executor and
+        # sends EOF to the shell's stdin, so the exec'd process exits.
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+        if reader is not None:
+            reader.cancel()

--- a/backend/atlas_backend/migrations/0015_alter_team_password.py
+++ b/backend/atlas_backend/migrations/0015_alter_team_password.py
@@ -1,0 +1,20 @@
+import atlas_backend.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("atlas_backend", "0014_remove_team_description_alter_team_password"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="team",
+            name="password",
+            field=models.CharField(
+                default=atlas_backend.models.default_team_password,
+                max_length=128,
+            ),
+        ),
+    ]

--- a/backend/atlas_backend/models.py
+++ b/backend/atlas_backend/models.py
@@ -7,6 +7,11 @@ from django.core.validators import RegexValidator
 import re
 import uuid
 
+
+def default_team_password():
+    return make_password("default_password")
+
+
 def validate_team_name(value):
     pattern = r'^[a-zA-Z0-9][a-zA-Z0-9_.-]*$'
     if not re.match(pattern, value):
@@ -27,7 +32,7 @@ class Team(models.Model):
     challenges = models.ManyToManyField("Challenge", blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    password = models.CharField(max_length=128, default=make_password('default_password'))
+    password = models.CharField(max_length=128, default=default_team_password)
     team_score = models.IntegerField(default=0)
     is_banned = models.BooleanField(default=False)
     is_hidden = models.BooleanField(default=False)

--- a/backend/atlas_backend/routing.py
+++ b/backend/atlas_backend/routing.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    path(
+        "ws/terminal/<int:challenge_id>/",
+        consumers.TerminalConsumer.as_asgi(),
+        name="terminal",
+    ),
+]

--- a/backend/atlas_backend/urls.py
+++ b/backend/atlas_backend/urls.py
@@ -7,8 +7,8 @@ urlpatterns = [
     path('auth/signup', views.register, name='register'),
     path('auth/login', views.signin, name='signin'),
     path('auth/refresh', views.token_refresh, name='token_refresh'),
-    path('auth/forgot-password', views.request_password_reset, name='request_password_reset'),  
-    path('auth/reset-password', views.reset_password, name='reset_password'),  
+    path('auth/forgot-password', views.request_password_reset, name='request_password_reset'),
+    path('auth/reset-password', views.reset_password, name='reset_password'),
     
     # Challenge routes
     path('challenges', views.get_challenges, name='get_challenges'),
@@ -31,7 +31,7 @@ urlpatterns = [
 
     # Scoreboard route
     path('scoreboard', views.get_scoreboard, name='get_scoreboard'),
-    path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('auth/token/refresh/', TokenRefreshView.as_view(), name='simplejwt_token_refresh'),
 
 
     # Admin routes

--- a/backend/atlas_backend/views.py
+++ b/backend/atlas_backend/views.py
@@ -16,6 +16,7 @@ from rest_framework_simplejwt.tokens import RefreshToken, AccessToken
 from django.core.cache import cache
 from django.db import transaction
 from django.http import QueryDict
+from django.utils import timezone
 from .models import User, Challenge, Submission, Team, Container, HintPurchase, validate_team_name
 from .serializers import SignupSerializer, ChallengeSerializer, TeamSerializer, SubmissionSerializer, UserSerializer
 import re
@@ -65,6 +66,9 @@ def register(request):
         
         # Generate tokens for automatic login
         refresh = RefreshToken.for_user(user)
+        refresh['user_id'] = user.id
+        refresh['username'] = user.username
+        refresh['email'] = user.email
         
         return Response({
             'user': {
@@ -590,30 +594,43 @@ def start_challenge(request, challenge_id):
         )
         
     challenge = get_object_or_404(Challenge, id=challenge_id)
+    container_name = f"{request.user.team.name.replace(' ', '_')}-{challenge.title.replace(' ', '_')}"
 
     existing_container = Container.objects.filter(
         team=request.user.team,
         challenge=challenge,
-        created_at__gte=datetime.now() - timedelta(minutes=10)
+        created_at__gte=timezone.now() - timedelta(minutes=10)
     ).first()
 
     if existing_container:
-        return Response({
+        response_data = {
             'host': existing_container.ssh_host,
             'port': existing_container.ssh_port,
-            'ssh_user': existing_container.ssh_user,
-            'ssh_password': existing_container.ssh_password,
             'created_at': existing_container.created_at,
-        })
+        }
+        if existing_container.ssh_user:
+            response_data['ssh_user'] = existing_container.ssh_user
+            response_data['ssh_password'] = existing_container.ssh_password
+        return Response(response_data)
 
     try:
         client = DockerPlugin(base_url=settings.DOCKER_HOST,key_file=settings.SSH_KEY_FILE)
+        # If a previous attempt leaked a container without a DB row, remove it
+        # before starting a replacement with the same deterministic name.
+        client.stop_container(container_name)
 
-        container_id, password = client.run_container(
+        result = client.run_container(
             challenge.docker_image,
             port=challenge.port,
-            container_name=f"{request.user.team.name.replace(' ', '_')}-{challenge.title.replace(' ', '_')}"
+            container_name=container_name,
+            environment={
+                'SSH_USER': challenge.ssh_user,
+            } if challenge.ssh_user else None,
         )
+        if not result:
+            raise Exception("Failed to start challenge container")
+
+        container_id, password = result
 
         import time
         timeout = 30
@@ -624,19 +641,24 @@ def start_challenge(request, challenge_id):
                 break
             time.sleep(1)
             if time.time() - start_time > timeout:
+                client.stop_container(container_id)
                 return Response(
                     {'error': 'Timeout waiting for container ports'},
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR
                 )
-        container = Container.objects.create(
-            team=request.user.team,
-            challenge=challenge,
-            container_id=container_id,
-            ssh_host=settings.SSH_HOST_URL,
-            ssh_port=ports[f'{challenge.port}/tcp'][0]['HostPort'],
-            ssh_user=challenge.ssh_user,
-            ssh_password=password,
-        )
+        try:
+            container = Container.objects.create(
+                team=request.user.team,
+                challenge=challenge,
+                container_id=container_id,
+                ssh_host=settings.SSH_HOST_URL,
+                ssh_port=ports[f'{challenge.port}/tcp'][0]['HostPort'],
+                ssh_user=challenge.ssh_user or '',
+                ssh_password=password,
+            )
+        except Exception:
+            client.stop_container(container_id)
+            raise
 
         if challenge.ssh_user:
             return Response({
@@ -675,7 +697,7 @@ def stop_challenge(request, challenge_id):
         existing_container = Container.objects.filter(
             team=request.user.team,
             challenge=challenge,
-            created_at__gte=datetime.now() - timedelta(minutes=10)
+            created_at__gte=timezone.now() - timedelta(minutes=10)
         ).first()
 
         if existing_container:
@@ -1060,7 +1082,7 @@ def update_challenge(request, challenge_id):
                 data['docker_image'] = image_id
             except Exception as e:
                 logger.error(f"Docker image upload error: {str(e)}")
-                raise Exception("Failed to upload docker image")
+                raise Exception(f"Failed to upload docker image: {str(e)}")
 
         if 'ssh_user' in data:
             try:
@@ -1478,7 +1500,7 @@ def get_dashboard_stats(request):
         stats = {
             'teams': {
                 'total': Team.objects.count(),
-                'active': Team.objects.filter(submissions__timestamp__gte=datetime.now() - timedelta(days=1)).distinct().count()
+                'active': Team.objects.filter(submissions__timestamp__gte=timezone.now() - timedelta(days=1)).distinct().count()
             },
             'challenges': {
                 'total': Challenge.objects.count(),
@@ -1487,12 +1509,12 @@ def get_dashboard_stats(request):
             },
             'containers': {
                 'total': Container.objects.count(),
-                'running': Container.objects.filter(created_at__gte=datetime.now() - timedelta(minutes=10)).count()
+                'running': Container.objects.filter(created_at__gte=timezone.now() - timedelta(minutes=10)).count()
             },
             'submissions': {
                 'total': Submission.objects.count(),
                 'correct': Submission.objects.filter(is_correct=True).count(),
-                'last_24h': Submission.objects.filter(timestamp__gte=datetime.now() - timedelta(days=1)).count()
+                'last_24h': Submission.objects.filter(timestamp__gte=timezone.now() - timedelta(days=1)).count()
             }
         }
         return Response(stats)

--- a/backend/atlas_backend/views.py
+++ b/backend/atlas_backend/views.py
@@ -595,6 +595,20 @@ def start_challenge(request, challenge_id):
         
     challenge = get_object_or_404(Challenge, id=challenge_id)
     container_name = f"{request.user.team.name.replace(' ', '_')}-{challenge.title.replace(' ', '_')}"
+    # Terminal (docker exec) is the DEFAULT interaction model: the in-browser
+    # terminal (/ws/terminal/<id>/) execs into the container over the Docker
+    # API — no SSH, no published port. A challenge is only treated as a
+    # published-port *service* challenge when it explicitly declares a service
+    # port AND has no shell user set. This makes the safe mode the default: a
+    # half-configured challenge gets a working terminal instead of silently
+    # exposing a dead host port.
+    #
+    # ssh_user, when set, names the unprivileged user to exec as; for terminal
+    # challenges it defaults to "atlas" (matching the challenge image's own
+    # default), so forgetting the field no longer breaks the challenge.
+    is_service = bool(challenge.port) and not challenge.ssh_user
+    uses_terminal = not is_service
+    exec_user = (challenge.ssh_user or 'atlas') if uses_terminal else ''
 
     existing_container = Container.objects.filter(
         team=request.user.team,
@@ -604,13 +618,13 @@ def start_challenge(request, challenge_id):
 
     if existing_container:
         response_data = {
-            'host': existing_container.ssh_host,
-            'port': existing_container.ssh_port,
+            'status': 'running',
+            'terminal': bool(existing_container.ssh_user),
             'created_at': existing_container.created_at,
         }
-        if existing_container.ssh_user:
-            response_data['ssh_user'] = existing_container.ssh_user
-            response_data['ssh_password'] = existing_container.ssh_password
+        if not existing_container.ssh_user:
+            response_data['host'] = existing_container.ssh_host
+            response_data['port'] = existing_container.ssh_port
         return Response(response_data)
 
     try:
@@ -618,62 +632,71 @@ def start_challenge(request, challenge_id):
         # If a previous attempt leaked a container without a DB row, remove it
         # before starting a replacement with the same deterministic name.
         client.stop_container(container_name)
+        # Any leftover records are stale (outside the reuse window) and point
+        # at the container stopped above; drop them so the terminal proxy
+        # can't connect to a dead host.
+        Container.objects.filter(team=request.user.team, challenge=challenge).delete()
 
         result = client.run_container(
             challenge.docker_image,
             port=challenge.port,
             container_name=container_name,
-            environment={
-                'SSH_USER': challenge.ssh_user,
-            } if challenge.ssh_user else None,
+            environment={'SSH_USER': exec_user} if uses_terminal else None,
+            network=settings.CHALLENGE_NETWORK if uses_terminal else None,
+            publish_port=not uses_terminal,
         )
         if not result:
             raise Exception("Failed to start challenge container")
 
         container_id, password = result
 
-        import time
-        timeout = 30
-        start_time = time.time()
-        while True:
-            ports = client.get_container_ports(container_id)
-            if ports:
-                break
-            time.sleep(1)
-            if time.time() - start_time > timeout:
-                client.stop_container(container_id)
-                return Response(
-                    {'error': 'Timeout waiting for container ports'},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
-                )
+        if uses_terminal:
+            # The terminal execs in by container id over the docker socket, so
+            # no host/port is needed; these columns are kept only to satisfy
+            # the existing schema. The container stays on the internal network
+            # (no host exposure, no outbound internet).
+            ssh_host = container_name
+            ssh_port = challenge.port or 22
+        else:
+            timeout = 30
+            start_time = time.time()
+            while True:
+                ports = client.get_container_ports(container_id)
+                if ports:
+                    break
+                time.sleep(1)
+                if time.time() - start_time > timeout:
+                    client.stop_container(container_id)
+                    return Response(
+                        {'error': 'Timeout waiting for container ports'},
+                        status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    )
+            ssh_host = settings.SSH_HOST_URL
+            ssh_port = ports[f'{challenge.port}/tcp'][0]['HostPort']
+
         try:
             container = Container.objects.create(
                 team=request.user.team,
                 challenge=challenge,
                 container_id=container_id,
-                ssh_host=settings.SSH_HOST_URL,
-                ssh_port=ports[f'{challenge.port}/tcp'][0]['HostPort'],
-                ssh_user=challenge.ssh_user or '',
+                ssh_host=ssh_host,
+                ssh_port=ssh_port,
+                ssh_user=exec_user,
                 ssh_password=password,
             )
         except Exception:
             client.stop_container(container_id)
             raise
 
-        if challenge.ssh_user:
-            return Response({
-                'host': container.ssh_host,
-                'port': container.ssh_port,
-                'ssh_user': container.ssh_user,
-                'ssh_password': container.ssh_password,
-                'created_at': container.created_at
-            })
-        else:
-            return Response({
-                'host': container.ssh_host,
-                'port': container.ssh_port,
-                'created_at': container.created_at
-            })
+        response_data = {
+            'status': 'running',
+            'terminal': uses_terminal,
+            'created_at': container.created_at,
+        }
+        if not uses_terminal:
+            response_data['host'] = container.ssh_host
+            response_data['port'] = container.ssh_port
+        return Response(response_data)
 
     except Exception as e:
         return Response(
@@ -694,11 +717,12 @@ def stop_challenge(request, challenge_id):
 
         challenge = get_object_or_404(Challenge, id=challenge_id)
 
+        # No freshness window here: a container must be stoppable for as long
+        # as its record exists, otherwise it leaks once the reuse window ends.
         existing_container = Container.objects.filter(
             team=request.user.team,
             challenge=challenge,
-            created_at__gte=timezone.now() - timedelta(minutes=10)
-        ).first()
+        ).order_by('-created_at').first()
 
         if existing_container:
             client = DockerPlugin(base_url=settings.DOCKER_HOST,key_file=settings.SSH_KEY_FILE)

--- a/backend/atlas_backend/ws_auth.py
+++ b/backend/atlas_backend/ws_auth.py
@@ -1,0 +1,46 @@
+"""JWT authentication middleware for WebSocket connections.
+
+Browsers cannot set an ``Authorization`` header on a WebSocket handshake, so
+the frontend passes the simplejwt access token as a ``token`` query parameter:
+
+    wss://host/ws/terminal/<challenge_id>/?token=<access>
+
+The middleware validates the token the same way CustomJWTAuthentication does
+for HTTP requests and stores the resolved user on ``scope["user"]`` (``None``
+when the token is missing or invalid; consumers decide how to reject).
+"""
+
+from urllib.parse import parse_qs
+
+from channels.db import database_sync_to_async
+from django.db import close_old_connections
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import AccessToken
+
+
+@database_sync_to_async
+def get_user_from_token(token):
+    from .models import User
+
+    # Recycle stale/broken DB connections before hitting the ORM from a
+    # long-lived ASGI worker.
+    close_old_connections()
+
+    if not token:
+        return None
+    try:
+        validated = AccessToken(token)  # verifies signature and expiry
+        return User.objects.select_related("team").get(id=validated["user_id"])
+    except (TokenError, KeyError, User.DoesNotExist):
+        return None
+
+
+class JWTAuthMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        query_string = scope.get("query_string", b"").decode()
+        token = parse_qs(query_string).get("token", [None])[0]
+        scope["user"] = await get_user_from_token(token)
+        return await self.app(scope, receive, send)

--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -3,6 +3,10 @@ ASGI config for backend project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 
+HTTP requests are served by the regular Django application; ``websocket``
+connections are routed through JWT auth middleware to the terminal-proxy
+consumers (see atlas_backend/consumers.py).
+
 For more information on this file, see
 https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 """
@@ -13,4 +17,17 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
-application = get_asgi_application()
+# Initialize Django before importing anything that touches the ORM/models.
+django_asgi_app = get_asgi_application()
+
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+
+from atlas_backend.routing import websocket_urlpatterns  # noqa: E402
+from atlas_backend.ws_auth import JWTAuthMiddleware  # noqa: E402
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": JWTAuthMiddleware(URLRouter(websocket_urlpatterns)),
+    }
+)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from pathlib import Path
 import os
+from urllib.parse import urlparse
 from dotenv import load_dotenv
 from datetime import timedelta
 import django.conf
@@ -30,11 +31,18 @@ SECRET_KEY = (
 DEBUG = False
 
 HOST_URL = os.getenv("HOST_URL", "http://localhost")
-DOCKER_HOST_URL = os.getenv('DOCKER_HOST_URL', "unix://var/run/docker.sock")
-SSH_HOST_URL = os.getenv('DOCKER_HOST_URL', HOST_URL)
-KEY_FILE_PATH = os.getenv('KEY_FILE_PATH', None)
+FRONTEND_URL = os.getenv("FRONTEND_URL", HOST_URL)
 
-ALLOWED_HOSTS = [HOST_URL]
+# Preserve both legacy and current setting names because the views reference
+# DOCKER_HOST and SSH_KEY_FILE directly.
+DOCKER_HOST = os.getenv('DOCKER_HOST_URL', "unix://var/run/docker.sock")
+DOCKER_HOST_URL = DOCKER_HOST
+SSH_HOST_URL = os.getenv('SSH_HOST_URL', HOST_URL)
+SSH_KEY_FILE = os.getenv('KEY_FILE_PATH') or None
+KEY_FILE_PATH = SSH_KEY_FILE
+HOST_NAME = urlparse(HOST_URL).hostname or HOST_URL
+
+ALLOWED_HOSTS = [HOST_NAME, "localhost", "127.0.0.1", "backend"]
 
 # Application definition
 
@@ -98,8 +106,8 @@ DATABASES = {
         "NAME": os.getenv("DB_NAME"),
         "USER": os.getenv("DB_USER"),
         "PASSWORD": os.getenv("DB_PASSWORD"),
-        "HOST": os.getenv("DB_HOST"),
-        "PORT": os.getenv("DB_PORT"),
+        "HOST": os.getenv("DB_HOST", "localhost"),
+        "PORT": os.getenv("DB_PORT", "5432"),
     }
 }
 AUTH_USER_MODEL = "atlas_backend.User"

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -40,6 +40,11 @@ DOCKER_HOST_URL = DOCKER_HOST
 SSH_HOST_URL = os.getenv('SSH_HOST_URL', HOST_URL)
 SSH_KEY_FILE = os.getenv('KEY_FILE_PATH') or None
 KEY_FILE_PATH = SSH_KEY_FILE
+# Internal docker network for terminal challenge containers: no host exposure
+# and (internal: true) no outbound internet. The terminal itself reaches them
+# via `docker exec`, not this network. Must match the challenge-net "name:" in
+# docker-compose.yml.
+CHALLENGE_NETWORK = os.getenv('CHALLENGE_NETWORK', 'atlas-challenges')
 HOST_NAME = urlparse(HOST_URL).hostname or HOST_URL
 
 ALLOWED_HOSTS = [HOST_NAME, "localhost", "127.0.0.1", "backend"]
@@ -47,6 +52,7 @@ ALLOWED_HOSTS = [HOST_NAME, "localhost", "127.0.0.1", "backend"]
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",  # ASGI server; must come first so runserver speaks ASGI/WebSocket
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -55,6 +61,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "corsheaders",
+    "channels",
     "atlas_backend",  # Your app
 ]
 
@@ -99,6 +106,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "backend.wsgi.application"
+ASGI_APPLICATION = "backend.asgi.application"
 
 DATABASES = {
     "default": {

--- a/backend/code/entrypoint.sh
+++ b/backend/code/entrypoint.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-python manage.py makemigrations
-python manage.py migrate
+python manage.py migrate --noinput
 
 
 exec "$@"

--- a/backend/docker_plugin.py
+++ b/backend/docker_plugin.py
@@ -2,7 +2,7 @@ from docker import DockerClient, APIClient
 from docker.transport import SSHHTTPAdapter
 import secrets
 import logging
-from docker.errors import APIError
+from docker.errors import APIError, NotFound
 
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s", level=logging.ERROR
@@ -15,7 +15,7 @@ ALLOWED_CHARACTERS = (
 
 class DockerPlugin:
     def __init__(self, base_url: str = "unix://var/run/docker.sock", key_file: str = None):
-        if key_file is None:
+        if key_file is None or not str(base_url).startswith("ssh://"):
             self.docker_client = DockerClient(base_url=base_url)
         else:
             class MySSHHTTPAdapter(SSHHTTPAdapter):
@@ -42,7 +42,13 @@ class DockerPlugin:
             logging.error(error)
         return None
 
-    def run_container(self, image: str, port: int, container_name: str = None):
+    def run_container(
+        self,
+        image: str,
+        port: int,
+        container_name: str = None,
+        environment: dict | None = None,
+    ):
         try:
             password = "".join(
                 secrets.choice(ALLOWED_CHARACTERS) for _ in range(16)
@@ -54,13 +60,17 @@ class DockerPlugin:
                 "memory": "128m",
             }
 
+            runtime_environment = {"PASS": password}
+            if environment:
+                runtime_environment.update(environment)
+
             container = self.docker_client.containers.run(
                 image,
                 detach=True,
                 auto_remove=True,
                 tty=True,
                 name=container_name,
-                environment={"PASS": password},
+                environment=runtime_environment,
                 ports={f"{port}/tcp": None},
                 cpu_quota=resources["cpu_quota"],
                 cpu_period=resources["cpu_period"],
@@ -76,6 +86,8 @@ class DockerPlugin:
             container = self.docker_client.containers.get(container_id)
             container.stop()
             return True
+        except NotFound:
+            return False
         except APIError as error:
             logging.error(error)
         return False

--- a/backend/docker_plugin.py
+++ b/backend/docker_plugin.py
@@ -45,9 +45,11 @@ class DockerPlugin:
     def run_container(
         self,
         image: str,
-        port: int,
+        port: int | None = None,
         container_name: str = None,
         environment: dict | None = None,
+        network: str | None = None,
+        publish_port: bool = False,
     ):
         try:
             password = "".join(
@@ -64,6 +66,17 @@ class DockerPlugin:
             if environment:
                 runtime_environment.update(environment)
 
+            extra_kwargs = {}
+            if network:
+                # Attach to the internal challenge network: the container is
+                # reachable from the backend by container name (docker DNS),
+                # with no ports published on the host.
+                extra_kwargs["network"] = network
+            if publish_port and port:
+                # Non-SSH challenges: publish the service port on a random
+                # host port so users can reach it directly.
+                extra_kwargs["ports"] = {f"{port}/tcp": None}
+
             container = self.docker_client.containers.run(
                 image,
                 detach=True,
@@ -71,10 +84,10 @@ class DockerPlugin:
                 tty=True,
                 name=container_name,
                 environment=runtime_environment,
-                ports={f"{port}/tcp": None},
                 cpu_quota=resources["cpu_quota"],
                 cpu_period=resources["cpu_period"],
                 mem_limit=resources["memory"],
+                **extra_kwargs,
             )
             return container.id, password
         except APIError as error:
@@ -122,3 +135,52 @@ class DockerPlugin:
         except APIError as error:
             logging.error(error)
         return None
+
+    def start_exec(
+        self,
+        container_id: str,
+        user: str | None = None,
+        cmd=("/bin/sh",),
+        rows: int = 24,
+        cols: int = 80,
+    ):
+        """Open an interactive `docker exec` shell and return (exec_id, socket).
+
+        The socket is a raw, bidirectional stream (TTY mode, not multiplexed):
+        write keystrokes with ``sendall`` and read terminal output with
+        ``recv``. Used by the WebSocket terminal proxy instead of SSH. Raises
+        on failure so the caller can reject the connection.
+        """
+        api = self.docker_client.api
+        exec_id = api.exec_create(
+            container_id,
+            cmd=list(cmd),
+            stdin=True,
+            stdout=True,
+            stderr=True,
+            tty=True,
+            # Run as the unprivileged challenge user, never root — otherwise a
+            # player could read every flag.txt regardless of its 0600 owner.
+            user=user or "",
+            environment=["TERM=xterm-256color"],
+        )["Id"]
+        sock_io = api.exec_start(exec_id, tty=True, socket=True, demux=False)
+        # docker-py wraps the hijacked connection in a socket.SocketIO; the
+        # underlying socket.socket (which owns the fd) is on ._sock and exposes
+        # recv()/sendall()/close().
+        raw_socket = getattr(sock_io, "_sock", sock_io)
+        try:
+            api.exec_resize(exec_id, height=rows, width=cols)
+        except APIError as error:
+            logging.error(error)
+        return exec_id, raw_socket
+
+    def resize_exec(self, exec_id: str, rows: int, cols: int):
+        try:
+            self.docker_client.api.exec_resize(
+                exec_id, height=rows, width=cols
+            )
+            return True
+        except APIError as error:
+            logging.error(error)
+        return False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,8 +2,10 @@ asgiref==3.8.1
 bcrypt==4.2.1
 certifi==2024.12.14
 cffi==1.17.1
+channels==4.2.0
 charset-normalizer==3.4.1
 cryptography==44.0.0
+daphne==4.1.2
 Django==5.1.7
 django-cors-headers==4.6.0
 djangorestframework==3.15.2

--- a/challenge.Dockerfile
+++ b/challenge.Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Make sure to include ssh-server with anyother dependencies you need and keep in mind the user cannot install any package on the fly and ideally wont have root access
-RUN apk add --no-cache openssh-server && \
+RUN apk add --no-cache openssh-server shadow && \
     adduser -D atlas && \
     ssh-keygen -A
 
@@ -12,10 +12,12 @@ RUN chmod +x /home/atlas/challenge.sh
 
 USER atlas
 
-# Do your build here
+# Do your build here if you need unprivileged build steps.
 
 USER root
-# since the sshd process requires root access to start change user root before ending the build
-# The startup script can also be changed as long as use remember to set your user password (need not be atlas can be anything like a hint) and  
+# The final image user stays root because sshd needs it to start on port 22.
+# The SSH login account is selected at runtime through the SSH_USER env var.
+
+EXPOSE 22
 
 CMD [ "/bin/sh", "-c", "/home/atlas/challenge.sh" ]

--- a/challenge.Dockerfile
+++ b/challenge.Dockerfile
@@ -1,23 +1,22 @@
 FROM alpine:latest
 
-# Make sure to include ssh-server with anyother dependencies you need and keep in mind the user cannot install any package on the fly and ideally wont have root access
-RUN apk add --no-cache openssh-server shadow && \
-    adduser -D atlas && \
-    ssh-keygen -A
+# No SSH server: the in-browser terminal reaches this container via
+# `docker exec`, not a network login. Keep the image minimal. The
+# unprivileged login user is created at build time and can be overridden at
+# runtime via the SSH_USER env var. The user cannot install packages on the
+# fly and should not have root access.
+RUN adduser -D atlas
 
 WORKDIR /home/atlas/
 
 COPY challenge.sh /home/atlas/challenge.sh
 RUN chmod +x /home/atlas/challenge.sh
 
-USER atlas
+# Do unprivileged build steps here if you need them, e.g.:
+#   USER atlas
+#   RUN ...
+#   USER root
 
-# Do your build here if you need unprivileged build steps.
-
-USER root
-# The final image user stays root because sshd needs it to start on port 22.
-# The SSH login account is selected at runtime through the SSH_USER env var.
-
-EXPOSE 22
-
+# The entrypoint runs as root so it can create the runtime user and lock down
+# flag permissions; the terminal itself execs in as the unprivileged user.
 CMD [ "/bin/sh", "-c", "/home/atlas/challenge.sh" ]

--- a/challenge.sh
+++ b/challenge.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -eu
+
+SSH_USER="${SSH_USER:-atlas}"
+PASSWORD="${PASS:-atlas}"
+
+if ! printf '%s' "${SSH_USER}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]*[$]?$'; then
+    echo "Invalid SSH_USER: ${SSH_USER}" >&2
+    exit 1
+fi
+
+if ! id "${SSH_USER}" >/dev/null 2>&1; then
+    adduser -D "${SSH_USER}"
+fi
+
+USER_HOME="$(awk -F: -v user="${SSH_USER}" '$1 == user { print $6 }' /etc/passwd)"
+if [ -z "${USER_HOME}" ]; then
+    echo "Unable to resolve home directory for ${SSH_USER}" >&2
+    exit 1
+fi
+
+mkdir -p "${USER_HOME}"
+echo "${SSH_USER}:${PASSWORD}" | chpasswd
+
+mkdir -p /var/run/sshd
+
+cat > "${USER_HOME}/README.txt" <<EOF
+Atlas test challenge container
+
+SSH user: ${SSH_USER}
+The runtime password is injected through the PASS environment variable.
+This is only a starter image for testing Atlas challenge orchestration.
+EOF
+
+echo 'flag{atlas_test_challenge}' > "${USER_HOME}/flag.txt"
+
+chown "${SSH_USER}:${SSH_USER}" "${USER_HOME}/README.txt" "${USER_HOME}/flag.txt"
+chmod 644 "${USER_HOME}/README.txt"
+chmod 600 "${USER_HOME}/flag.txt"
+
+if grep -q '^#PasswordAuthentication' /etc/ssh/sshd_config; then
+    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+elif grep -q '^PasswordAuthentication' /etc/ssh/sshd_config; then
+    sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+else
+    echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
+fi
+
+if grep -q '^#PermitRootLogin' /etc/ssh/sshd_config; then
+    sed -i 's/^#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+elif grep -q '^PermitRootLogin' /etc/ssh/sshd_config; then
+    sed -i 's/^PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+else
+    echo 'PermitRootLogin no' >> /etc/ssh/sshd_config
+fi
+
+exec /usr/sbin/sshd -D -e -p 22

--- a/challenge.sh
+++ b/challenge.sh
@@ -2,57 +2,44 @@
 
 set -eu
 
-SSH_USER="${SSH_USER:-atlas}"
-PASSWORD="${PASS:-atlas}"
+# The unprivileged user the in-browser terminal execs into (docker exec
+# --user). There is no SSH daemon: the terminal arrives over the Docker API.
+# The env var is still called SSH_USER for backwards compatibility with the
+# orchestrator.
+SHELL_USER="${SSH_USER:-atlas}"
 
-if ! printf '%s' "${SSH_USER}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]*[$]?$'; then
-    echo "Invalid SSH_USER: ${SSH_USER}" >&2
+if ! printf '%s' "${SHELL_USER}" | grep -Eq '^[A-Za-z_][A-Za-z0-9_-]*[$]?$'; then
+    echo "Invalid SSH_USER: ${SHELL_USER}" >&2
     exit 1
 fi
 
-if ! id "${SSH_USER}" >/dev/null 2>&1; then
-    adduser -D "${SSH_USER}"
+if ! id "${SHELL_USER}" >/dev/null 2>&1; then
+    adduser -D "${SHELL_USER}"
 fi
 
-USER_HOME="$(awk -F: -v user="${SSH_USER}" '$1 == user { print $6 }' /etc/passwd)"
+USER_HOME="$(awk -F: -v user="${SHELL_USER}" '$1 == user { print $6 }' /etc/passwd)"
 if [ -z "${USER_HOME}" ]; then
-    echo "Unable to resolve home directory for ${SSH_USER}" >&2
+    echo "Unable to resolve home directory for ${SHELL_USER}" >&2
     exit 1
 fi
 
 mkdir -p "${USER_HOME}"
-echo "${SSH_USER}:${PASSWORD}" | chpasswd
-
-mkdir -p /var/run/sshd
 
 cat > "${USER_HOME}/README.txt" <<EOF
 Atlas test challenge container
 
-SSH user: ${SSH_USER}
-The runtime password is injected through the PASS environment variable.
-This is only a starter image for testing Atlas challenge orchestration.
+Shell user: ${SHELL_USER}
+You reach this container through the in-browser terminal (docker exec) —
+there is no SSH. This is only a starter image for testing Atlas challenge
+orchestration.
 EOF
 
 echo 'flag{atlas_test_challenge}' > "${USER_HOME}/flag.txt"
 
-chown "${SSH_USER}:${SSH_USER}" "${USER_HOME}/README.txt" "${USER_HOME}/flag.txt"
+chown "${SHELL_USER}:${SHELL_USER}" "${USER_HOME}/README.txt" "${USER_HOME}/flag.txt"
 chmod 644 "${USER_HOME}/README.txt"
 chmod 600 "${USER_HOME}/flag.txt"
 
-if grep -q '^#PasswordAuthentication' /etc/ssh/sshd_config; then
-    sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-elif grep -q '^PasswordAuthentication' /etc/ssh/sshd_config; then
-    sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-else
-    echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
-fi
-
-if grep -q '^#PermitRootLogin' /etc/ssh/sshd_config; then
-    sed -i 's/^#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
-elif grep -q '^PermitRootLogin' /etc/ssh/sshd_config; then
-    sed -i 's/^PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
-else
-    echo 'PermitRootLogin no' >> /etc/ssh/sshd_config
-fi
-
-exec /usr/sbin/sshd -D -e -p 22
+# No SSH daemon: the terminal is delivered via `docker exec`. Keep the
+# container alive so the orchestrator can exec into it on demand.
+exec tail -f /dev/null

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -69,8 +69,10 @@ services:
       - DB_HOST=db
       - DB_PORT=5432
       - DEBUG=1
+      - CHALLENGE_NETWORK=${CHALLENGE_NETWORK:-atlas-challenges}
     networks:
       - app-network
+      - challenge-net
     restart: always
     depends_on:
       - db
@@ -82,3 +84,12 @@ volumes:
 networks:
   app-network:
     driver: bridge
+  challenge-net:
+    # Explicit name: challenge containers are started via the host docker
+    # socket (siblings, not compose services), so they must join this network
+    # by its real name rather than the compose-prefixed one.
+    name: ${CHALLENGE_NETWORK:-atlas-challenges}
+    driver: bridge
+    # No route to the outside world: challenge containers are reachable only
+    # from services on this network (the backend's WebSocket-SSH proxy).
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       interval: 3s
       timeout: 60s
       retries: 5
-    restart : always
+    restart: unless-stopped
 
   pgadmin:
     image: dpage/pgadmin4
@@ -31,7 +31,7 @@ services:
       - pgadmin_data:/var/lib/pgadmin
     networks:
       - app-network
-    restart: always
+    restart: unless-stopped
     depends_on:
       - db
 
@@ -46,7 +46,7 @@ services:
       - .env
     networks:
       - app-network
-    restart: always
+    restart: unless-stopped
     depends_on:
       - backend
 
@@ -62,11 +62,13 @@ services:
     env_file:
       - .env
     environment:
+      CHALLENGE_NETWORK: ${CHALLENGE_NETWORK:-atlas-challenges}
       DB_HOST: ${DB_HOST:-db}
       DB_PORT: ${DB_PORT:-5432}
     networks:
       - app-network
-    restart: always
+      - challenge-net
+    restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
@@ -78,3 +80,12 @@ volumes:
 networks:
   app-network:
     driver: bridge
+  challenge-net:
+    # Explicit name: challenge containers are started via the host docker
+    # socket (siblings, not compose services), so they must join this network
+    # by its real name rather than the compose-prefixed one.
+    name: ${CHALLENGE_NETWORK:-atlas-challenges}
+    driver: bridge
+    # No route to the outside world: challenge containers are reachable only
+    # from services on this network (the backend's WebSocket-SSH proxy).
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,13 +57,19 @@ services:
     container_name: atlas_backend
     ports:
       - "8000:8000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - .env
+    environment:
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
     networks:
       - app-network
     restart: always
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,15 @@
+# Never copy the host's node_modules into the image: it carries the wrong
+# platform's binaries and a different pnpm store layout, which makes pnpm try
+# to wipe and reinstall node_modules mid-build (fails with no TTY).
+node_modules
+dist
+.git
+.gitignore
+.dockerignore
+Dockerfile
+Dockerfile.dev
+*.log
+npm-debug.log*
+.DS_Store
+.vscode
+.idea

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,14 @@
-# Use node.js as base image
-FROM node:23.1-alpine3.19
+# Use node.js as base image (Node 22 LTS: ships node:sqlite, which pnpm needs)
+FROM node:22-alpine
 
-# Install pnpm 
-RUN npm install -g pnpm
+# Install pnpm — pinned to match the committed lockfile (v9.0) and local toolchain
+RUN npm install -g pnpm@11.5.1
 
 # Set working directory
 WORKDIR /app
 
-# Copy package files and pnpm lock
-COPY package.json pnpm-lock.yaml ./
+# Copy package files, pnpm lock and workspace config (build-script approvals)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # INstall dependencies
 RUN pnpm install
@@ -16,7 +16,9 @@ RUN pnpm install
 # Copy rest of the application
 COPY . .
 
-RUN pnpm run build
+# Cap V8's heap so the Vite build uses the available RAM instead of V8's
+# (lower) in-container default. Raise this if you give Docker more memory.
+RUN NODE_OPTIONS=--max-old-space-size=768 pnpm run build
 
 #  Expose port for frontend
 EXPOSE 4173

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@tabler/icons-react": "^3.28.1",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "axios": "^1.8.2",
     "clsx": "^2.1.1",
     "framer-motion": "^11.18.1",
@@ -30,5 +32,10 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "vite": "^4.5.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,10 +10,16 @@ importers:
     dependencies:
       '@tabler/icons-react':
         specifier: ^3.28.1
-        version: 3.30.0(react@18.3.1)
+        version: 3.44.0(react@18.3.1)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       axios:
         specifier: ^1.8.2
-        version: 1.8.2
+        version: 1.17.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -34,38 +40,38 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-markdown:
         specifier: ^10.0.0
-        version: 10.0.0(@types/react@18.3.18)(react@18.3.1)
+        version: 10.1.0(@types/react@18.3.30)(react@18.3.1)
       react-router-dom:
         specifier: ^6.4.2
-        version: 6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
       tailwind-merge:
         specifier: ^2.6.0
-        version: 2.6.0
+        version: 2.6.1
     devDependencies:
       '@types/react':
         specifier: ^18.0.17
-        version: 18.3.18
+        version: 18.3.30
       '@types/react-dom':
         specifier: ^18.0.6
-        version: 18.3.5(@types/react@18.3.18)
+        version: 18.3.7(@types/react@18.3.30)
       '@vitejs/plugin-react':
         specifier: ^2.1.0
-        version: 2.2.0(vite@4.5.6)
+        version: 2.2.0(vite@4.5.14)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.20(postcss@8.5.3)
+        version: 10.5.0(postcss@8.5.15)
       postcss:
         specifier: ^8.4.49
-        version: 8.5.3
+        version: 8.5.15
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17
+        version: 3.4.19
       vite:
         specifier: ^4.5.6
-        version: 4.5.6
+        version: 4.5.14
 
 packages:
 
@@ -73,109 +79,109 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
-
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.8':
-    resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.26.9':
-    resolution: {integrity: sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.9':
-    resolution: {integrity: sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.25.9':
-    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.26.5':
-    resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.25.9':
-    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.26.0':
-    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.26.5':
-    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.25.9':
-    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.26.9':
-    resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==}
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.9':
-    resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-syntax-jsx@7.25.9':
-    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-development@7.25.9':
-    resolution: {integrity: sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==}
+  '@babel/plugin-transform-react-jsx-development@7.29.7':
+    resolution: {integrity: sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9':
-    resolution: {integrity: sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==}
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9':
-    resolution: {integrity: sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==}
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx@7.25.9':
-    resolution: {integrity: sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==}
+  '@babel/plugin-transform-react-jsx@7.29.7':
+    resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/template@7.26.9':
-    resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.26.9':
-    resolution: {integrity: sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==}
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.26.9':
-    resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@esbuild/android-arm64@0.18.20':
@@ -310,27 +316,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -344,30 +344,26 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-
-  '@remix-run/router@1.23.0':
-    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
-  '@tabler/icons-react@3.30.0':
-    resolution: {integrity: sha512-9KZ9D1UNAyjlLkkYp2HBPHdf6lAJ2aelDqh8YYAnnmLF3xwprWKxxW8+zw5jlI0IwdfN4XFFuzqePkaw+DpIOg==}
+  '@tabler/icons-react@3.44.0':
+    resolution: {integrity: sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==}
     peerDependencies:
       react: '>= 16'
 
-  '@tabler/icons@3.30.0':
-    resolution: {integrity: sha512-c8OKLM48l00u9TFbh2qhSODMONIzML8ajtCyq95rW8vzkWcBrKRPM61tdkThz2j4kd5u17srPGIjqdeRUZdfdw==}
+  '@tabler/icons@3.44.0':
+    resolution: {integrity: sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==}
 
-  '@types/debug@4.1.12':
-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -378,16 +374,16 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/prop-types@15.7.14':
-    resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react-dom@18.3.5':
-    resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
 
-  '@types/react@18.3.18':
-    resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
+  '@types/react@18.3.30':
+    resolution: {integrity: sha512-3ek6mwJL5/VBewBcY4S66cqlCtK3qi4WIq37Z0m/NHw1hjhI7274Mx1qz/+ggSzyBCOEf7eHjBN6INjPAWYfYw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -395,8 +391,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitejs/plugin-react@2.2.0':
     resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
@@ -404,21 +400,15 @@ packages:
     peerDependencies:
       vite: ^3.0.0
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
-  ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -433,35 +423,34 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  autoprefixer@10.4.20:
-    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.8.2:
-    resolution: {integrity: sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==}
+  axios@1.17.0:
+    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  baseline-browser-mapping@2.10.33:
+    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.24.4:
-    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -473,8 +462,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001701:
-    resolution: {integrity: sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -499,13 +488,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -520,20 +502,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -541,8 +519,8 @@ packages:
       supports-color:
         optional: true
 
-  decode-named-character-reference@1.0.2:
-    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -565,17 +543,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  electron-to-chromium@1.5.109:
-    resolution: {integrity: sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==}
-
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+  electron-to-chromium@1.5.366:
+    resolution: {integrity: sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -585,38 +554,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
-
-  esbuild-android-64@0.15.18:
-    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  esbuild-android-arm64@0.15.18:
-    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  esbuild-darwin-64@0.15.18:
-    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -646,15 +585,24 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fastq@1.19.1:
-    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -662,16 +610,12 @@ packages:
       debug:
         optional: true
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   framer-motion@11.18.2:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
@@ -715,14 +659,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
-
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -735,12 +671,12 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hast-util-to-jsx-runtime@2.3.5:
-    resolution: {integrity: sha512-gHD+HoFxOMmmXLuq9f2dZDMQHVcplCVpMfBNRpJsF03yyLZvJGzsFORe8orVuYDX9k2w0VH0uF8oryFd1whqKQ==}
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -748,8 +684,12 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
-  inline-style-parser@0.2.4:
-    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -761,8 +701,8 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
@@ -771,10 +711,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -790,12 +726,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -832,9 +762,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -852,8 +779,8 @@ packages:
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
-  mdast-util-from-markdown@2.0.2:
-    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
@@ -885,8 +812,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -994,14 +921,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
 
@@ -1014,20 +933,17 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
   object-assign@4.1.1:
@@ -1038,36 +954,29 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
   postcss-import@15.1.0:
@@ -1076,22 +985,28 @@ packages:
     peerDependencies:
       postcss: ^8.0.0
 
-  postcss-js@4.0.1:
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
 
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
     peerDependencies:
+      jiti: '>=1.21.0'
       postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
+      jiti:
+        optional: true
       postcss:
         optional: true
-      ts-node:
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-nested@6.2.0:
@@ -1107,18 +1022,19 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  property-information@7.0.0:
-    resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1131,8 +1047,8 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-markdown@10.0.0:
-    resolution: {integrity: sha512-4mTz7Sya/YQ1jYOrkwO73VcFdkFJ8L8I9ehCxdcV0XrClHyOJGKbBk5FR4OOOG+HnyKw5u+C/Aby9TwinCteYA==}
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
@@ -1141,15 +1057,15 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.30.0:
-    resolution: {integrity: sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==}
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.30.0:
-    resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -1171,14 +1087,14 @@ packages:
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
-  remark-rehype@11.1.1:
-    resolution: {integrity: sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==}
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  resolve@1.22.10:
-    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -1186,8 +1102,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@3.29.5:
-    resolution: {integrity: sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==}
+  rollup@3.30.0:
+    resolution: {integrity: sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1201,18 +1117,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1224,30 +1128,17 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
-  strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
-  style-to-object@1.0.8:
-    resolution: {integrity: sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==}
-
-  sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
@@ -1255,11 +1146,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwind-merge@2.6.0:
-    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -1269,6 +1160,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1289,8 +1184,8 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unist-util-is@6.0.0:
-    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -1298,14 +1193,14 @@ packages:
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
-  unist-util-visit-parents@6.0.1:
-    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -1313,14 +1208,14 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vfile-message@4.0.2:
-    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@4.5.6:
-    resolution: {integrity: sha512-ElBNuVvJKslxcfY2gMmae5IjaKGqCYGicCNZ+8R56sAznobeE3pI9ctzI17cBS/6OJh5YuQNMSN4BP4dRjugBg==}
+  vite@4.5.14:
+    resolution: {integrity: sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -1347,26 +1242,8 @@ packages:
       terser:
         optional: true
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@2.7.0:
-    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
-    engines: {node: '>= 14'}
-    hasBin: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1375,147 +1252,144 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@ampproject/remapping@2.3.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
-
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.26.8': {}
+  '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.26.9':
+  '@babel/core@7.29.7':
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.9
-      '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.9)
-      '@babel/helpers': 7.26.9
-      '@babel/parser': 7.26.9
-      '@babel/template': 7.26.9
-      '@babel/traverse': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.26.9':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.26.9
-      '@babel/types': 7.26.9
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.25.9':
+  '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
-      '@babel/types': 7.26.9
+      '@babel/types': 7.29.7
 
-  '@babel/helper-compilation-targets@7.26.5':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.26.8
-      '@babel/helper-validator-option': 7.25.9
-      browserslist: 4.24.4
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-module-imports@7.25.9':
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.9)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.9
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.26.5': {}
+  '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-string-parser@7.25.9': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.25.9': {}
+  '@babel/helper-validator-option@7.29.7': {}
 
-  '@babel/helpers@7.26.9':
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/parser@7.26.9':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.26.9
+      '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.9)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-development@7.25.9(@babel/core@7.26.9)':
+  '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.9)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.9)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.9)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx@7.25.9(@babel/core@7.26.9)':
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
-      '@babel/types': 7.26.9
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/template@7.26.9':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.9
-      '@babel/types': 7.26.9
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
-  '@babel/traverse@7.26.9':
+  '@babel/traverse@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.9
-      '@babel/parser': 7.26.9
-      '@babel/template': 7.26.9
-      '@babel/types': 7.26.9
-      debug: 4.4.0
-      globals: 11.12.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.26.9':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@esbuild/android-arm64@0.18.20':
     optional: true
@@ -1583,31 +1457,24 @@ snapshots:
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
-  '@isaacs/cliui@8.0.2':
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/gen-mapping@0.3.8':
+  '@jridgewell/remapping@2.3.5':
     dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1619,29 +1486,26 @@ snapshots:
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
+      fastq: 1.20.1
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
+  '@remix-run/router@1.23.3': {}
 
-  '@remix-run/router@1.23.0': {}
-
-  '@tabler/icons-react@3.30.0(react@18.3.1)':
+  '@tabler/icons-react@3.44.0(react@18.3.1)':
     dependencies:
-      '@tabler/icons': 3.30.0
+      '@tabler/icons': 3.44.0
       react: 18.3.1
 
-  '@tabler/icons@3.30.0': {}
+  '@tabler/icons@3.44.0': {}
 
-  '@types/debug@4.1.12':
+  '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
 
-  '@types/estree@1.0.6': {}
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1653,95 +1517,93 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/prop-types@15.7.14': {}
+  '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@18.3.5(@types/react@18.3.18)':
+  '@types/react-dom@18.3.7(@types/react@18.3.30)':
     dependencies:
-      '@types/react': 18.3.18
+      '@types/react': 18.3.30
 
-  '@types/react@18.3.18':
+  '@types/react@18.3.30':
     dependencies:
-      '@types/prop-types': 15.7.14
-      csstype: 3.1.3
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@2.2.0(vite@4.5.6)':
+  '@vitejs/plugin-react@2.2.0(vite@4.5.14)':
     dependencies:
-      '@babel/core': 7.26.9
-      '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-transform-react-jsx-development': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       magic-string: 0.26.7
       react-refresh: 0.14.2
-      vite: 4.5.6
+      vite: 4.5.14
     transitivePeerDependencies:
       - supports-color
 
-  ansi-regex@5.0.1: {}
+  '@xterm/addon-fit@0.11.0': {}
 
-  ansi-regex@6.1.0: {}
+  '@xterm/xterm@6.0.0': {}
 
-  ansi-styles@4.3.0:
+  agent-base@6.0.2:
     dependencies:
-      color-convert: 2.0.1
-
-  ansi-styles@6.2.1: {}
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@5.0.2: {}
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.3):
+  autoprefixer@10.5.0(postcss@8.5.15):
     dependencies:
-      browserslist: 4.24.4
-      caniuse-lite: 1.0.30001701
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.3
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
-  axios@1.8.2:
+  axios@1.17.0:
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  baseline-browser-mapping@2.10.33: {}
 
   binary-extensions@2.3.0: {}
-
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.24.4:
+  browserslist@4.28.2:
     dependencies:
-      caniuse-lite: 1.0.30001701
-      electron-to-chromium: 1.5.109
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.24.4)
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.366
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -1750,7 +1612,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001701: {}
+  caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
 
@@ -1776,12 +1638,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -1792,21 +1648,15 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   cssesc@3.0.0: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
-  debug@4.4.0:
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
-  decode-named-character-reference@1.0.2:
+  decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
@@ -1828,19 +1678,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
-  electron-to-chromium@1.5.109: {}
-
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
+  electron-to-chromium@1.5.366: {}
 
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -1849,7 +1693,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -1878,7 +1722,13 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  fast-glob@3.3.2:
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  extend@3.0.2: {}
+
+  fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -1886,29 +1736,29 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fastq@1.19.1:
+  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.16.0: {}
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
-  form-data@4.0.2:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
 
-  fraction.js@4.3.7: {}
+  fraction.js@5.3.4: {}
 
   framer-motion@11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -1931,18 +1781,18 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -1952,17 +1802,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
-  globals@11.12.0: {}
-
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -1971,13 +1810,13 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-to-jsx-runtime@2.3.5:
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -1987,11 +1826,11 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.0.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
-      style-to-object: 1.0.8
+      style-to-js: 1.1.21
       unist-util-position: 5.0.0
-      vfile-message: 4.0.2
+      vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2001,7 +1840,14 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
-  inline-style-parser@0.2.4: {}
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  inline-style-parser@0.2.7: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -2014,15 +1860,13 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2033,14 +1877,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  isexe@2.0.0: {}
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
@@ -2062,8 +1898,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@10.4.3: {}
-
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2080,14 +1914,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
-      decode-named-character-reference: 1.0.2
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
       micromark: 4.0.2
@@ -2112,7 +1946,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -2121,7 +1955,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2131,7 +1965,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2140,14 +1974,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -2163,7 +1997,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2176,12 +2010,12 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
       unist-util-stringify-position: 4.0.0
-      vfile-message: 4.0.2
+      vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2191,7 +2025,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2199,18 +2033,18 @@ snapshots:
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -2222,7 +2056,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -2233,7 +2067,7 @@ snapshots:
 
   micromark-core-commonmark@2.0.3:
     dependencies:
-      decode-named-character-reference: 1.0.2
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-factory-destination: 2.0.1
       micromark-factory-label: 2.0.1
@@ -2366,7 +2200,7 @@ snapshots:
 
   micromark-util-decode-string@2.0.1:
     dependencies:
-      decode-named-character-reference: 1.0.2
+      decode-named-character-reference: 1.3.0
       micromark-util-character: 2.1.1
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-symbol: 2.0.1
@@ -2402,9 +2236,9 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      '@types/debug': 4.1.12
-      debug: 4.4.0
-      decode-named-character-reference: 1.0.2
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-factory-space: 2.0.1
@@ -2425,19 +2259,13 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.1
-
-  minipass@7.1.2: {}
 
   motion-dom@11.18.1:
     dependencies:
@@ -2453,69 +2281,60 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.8: {}
+  nanoid@3.3.12: {}
 
-  node-releases@2.0.19: {}
+  node-releases@2.0.47: {}
 
   normalize-path@3.0.0: {}
-
-  normalize-range@0.1.2: {}
 
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
-
-  package-json-from-dist@1.0.1: {}
 
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
-      decode-named-character-reference: 1.0.2
+      decode-named-character-reference: 1.3.0
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  path-key@3.1.1: {}
-
   path-parse@1.0.7: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
 
   pify@2.3.0: {}
 
-  pirates@4.0.6: {}
+  pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.3):
+  postcss-import@15.1.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
-      resolve: 1.22.10
+      resolve: 1.22.12
 
-  postcss-js@4.0.1(postcss@8.5.3):
+  postcss-js@4.1.0(postcss@8.5.15):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.3
+      postcss: 8.5.15
 
-  postcss-load-config@4.0.2(postcss@8.5.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
     dependencies:
       lilconfig: 3.1.3
-      yaml: 2.7.0
     optionalDependencies:
-      postcss: 8.5.3
+      jiti: 1.21.7
+      postcss: 8.5.15
 
-  postcss-nested@6.2.0(postcss@8.5.3):
+  postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -2525,9 +2344,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.3:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2537,9 +2356,9 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  property-information@7.0.0: {}
+  property-information@7.2.0: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -2551,36 +2370,36 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-markdown@10.0.0(@types/react@18.3.18)(react@18.3.1):
+  react-markdown@10.1.0(@types/react@18.3.30)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/react': 18.3.18
+      '@types/react': 18.3.30
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.5
+      hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       react: 18.3.1
       remark-parse: 11.0.0
-      remark-rehype: 11.1.1
+      remark-rehype: 11.1.2
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.0(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
 
-  react-router@6.30.0(react@18.3.1):
+  react-router@6.30.4(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.0
+      '@remix-run/router': 1.23.3
       react: 18.3.1
 
   react@18.3.1:
@@ -2593,7 +2412,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   remark-gfm@4.0.1:
     dependencies:
@@ -2609,17 +2428,17 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-rehype@11.1.1:
+  remark-rehype@11.1.2:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
@@ -2629,15 +2448,16 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  resolve@1.22.10:
+  resolve@1.22.12:
     dependencies:
-      is-core-module: 2.16.1
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
-  rollup@3.29.5:
+  rollup@3.30.0:
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -2651,64 +2471,40 @@ snapshots:
 
   semver@6.3.1: {}
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  signal-exit@4.1.0: {}
-
   source-map-js@1.2.1: {}
 
   sourcemap-codec@1.4.8: {}
 
   space-separated-tokens@2.0.2: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
-  strip-ansi@6.0.1:
+  style-to-js@1.1.21:
     dependencies:
-      ansi-regex: 5.0.1
+      style-to-object: 1.0.14
 
-  strip-ansi@7.1.0:
+  style-to-object@1.0.14:
     dependencies:
-      ansi-regex: 6.1.0
+      inline-style-parser: 0.2.7
 
-  style-to-object@1.0.8:
+  sucrase@3.35.1:
     dependencies:
-      inline-style-parser: 0.2.4
-
-  sucrase@3.35.0:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
-      glob: 10.4.5
       lines-and-columns: 1.2.4
       mz: 2.7.0
-      pirates: 4.0.6
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwind-merge@2.6.0: {}
+  tailwind-merge@2.6.1: {}
 
-  tailwindcss@3.4.17:
+  tailwindcss@3.4.19:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -2724,16 +2520,17 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.3
-      postcss-import: 15.1.0(postcss@8.5.3)
-      postcss-js: 4.0.1(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)
-      postcss-nested: 6.2.0(postcss@8.5.3)
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
+      postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
+      resolve: 1.22.12
+      sucrase: 3.35.1
     transitivePeerDependencies:
-      - ts-node
+      - tsx
+      - yaml
 
   thenify-all@1.6.0:
     dependencies:
@@ -2742,6 +2539,11 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   to-regex-range@5.0.1:
     dependencies:
@@ -2765,7 +2567,7 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unist-util-is@6.0.0:
+  unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
 
@@ -2777,26 +2579,26 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@6.0.1:
+  unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
+      unist-util-is: 6.0.1
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
-  update-browserslist-db@1.1.3(browserslist@4.24.4):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.24.4
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
 
-  vfile-message@4.0.2:
+  vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
@@ -2804,34 +2606,16 @@ snapshots:
   vfile@6.0.3:
     dependencies:
       '@types/unist': 3.0.3
-      vfile-message: 4.0.2
+      vfile-message: 4.0.3
 
-  vite@4.5.6:
+  vite@4.5.14:
     dependencies:
       esbuild: 0.18.20
-      postcss: 8.5.3
-      rollup: 3.29.5
+      postcss: 8.5.15
+      rollup: 3.30.0
     optionalDependencies:
       fsevents: 2.3.3
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-
   yallist@3.1.1: {}
-
-  yaml@2.7.0: {}
 
   zwitch@2.0.4: {}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# pnpm requires explicit approval before running dependency build scripts.
+# esbuild (vite's bundler) uses a postinstall script to set up its platform binary.
+# allowBuilds is the pnpm >=11 setting; onlyBuiltDependencies covers pnpm 10.
+allowBuilds:
+  esbuild: true
+onlyBuiltDependencies:
+  - esbuild

--- a/frontend/src/api/challenges.js
+++ b/frontend/src/api/challenges.js
@@ -57,6 +57,16 @@ export const startChallenge = async (challengeId) => {
   }
 };
 
+export const stopChallenge = async (challengeId) => {
+  try {
+    const response = await apiClient.post(`/challenges/${challengeId}/stop`);
+    return response.data;
+  } catch (error) {
+    console.error('Failed to stop container');
+    throw error;
+  }
+};
+
 // Admin challenge APIs
 export const getAdminChallenges = async () => {
   try {

--- a/frontend/src/api/config.js
+++ b/frontend/src/api/config.js
@@ -1,6 +1,15 @@
 import axios from 'axios';
 
-export const API_URL = `${process.env.HOST_URL}:8000`;
+const getDefaultApiUrl = () => {
+  if (typeof window === 'undefined') {
+    return 'http://localhost:8000';
+  }
+
+  const { protocol, hostname } = window.location;
+  return `${protocol}//${hostname}:8000`;
+};
+
+export const API_URL = import.meta.env.VITE_API_URL || getDefaultApiUrl();
 
 const apiClient = axios.create({
   baseURL: API_URL,
@@ -12,6 +21,10 @@ const apiClient = axios.create({
 // Add request interceptor to include auth token
 apiClient.interceptors.request.use(
   (config) => {
+    if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+      delete config.headers['Content-Type'];
+    }
+
     const tokenString = localStorage.getItem('token');
     if (tokenString) {
       const { access } = JSON.parse(tokenString);

--- a/frontend/src/components/ChallengeTerminal.jsx
+++ b/frontend/src/components/ChallengeTerminal.jsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import { API_URL } from '../api/config';
+
+// Close codes sent by the backend terminal proxy (see consumers.py)
+const CLOSE_MESSAGES = {
+  4401: 'Session expired — please log in again.',
+  4403: 'Your team has been banned.',
+  4404: 'No running container found — start the challenge first.',
+  4502: 'Could not reach the challenge container — try restarting the challenge.',
+};
+
+const buildTerminalUrl = (challengeId) => {
+  const tokenString = localStorage.getItem('token');
+  const access = tokenString ? JSON.parse(tokenString).access : '';
+  const wsBase = API_URL.replace(/^http/, 'ws'); // http -> ws, https -> wss
+  return `${wsBase}/ws/terminal/${challengeId}/?token=${encodeURIComponent(access)}`;
+};
+
+/**
+ * Browser terminal for SSH challenges.
+ *
+ * Speaks the proxy's wire protocol: binary WebSocket frames carry raw
+ * terminal bytes, text frames carry JSON control messages such as
+ * {"type": "resize", "cols": 120, "rows": 32}.
+ */
+function ChallengeTerminal({ challengeId }) {
+  const containerRef = useRef(null);
+  const [status, setStatus] = useState('connecting'); // connecting | connected | closed
+  const [closeMessage, setCloseMessage] = useState('');
+  const [session, setSession] = useState(0); // bump to reconnect
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return undefined;
+
+    setStatus('connecting');
+    setCloseMessage('');
+
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: 14,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: {
+        background: '#1a1b26',
+        foreground: '#c0caf5',
+        cursor: '#c0caf5',
+        cursorAccent: '#1a1b26',
+        selectionBackground: '#33467c',
+        black: '#15161e',
+        red: '#f7768e',
+        green: '#9ece6a',
+        yellow: '#e0af68',
+        blue: '#7aa2f7',
+        magenta: '#bb9af7',
+        cyan: '#7dcfff',
+        white: '#a9b1d6',
+        brightBlack: '#414868',
+        brightRed: '#f7768e',
+        brightGreen: '#9ece6a',
+        brightYellow: '#e0af68',
+        brightBlue: '#7aa2f7',
+        brightMagenta: '#bb9af7',
+        brightCyan: '#7dcfff',
+        brightWhite: '#c0caf5',
+      },
+    });
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(node);
+    fitAddon.fit();
+
+    const ws = new WebSocket(buildTerminalUrl(challengeId));
+    ws.binaryType = 'arraybuffer';
+    const encoder = new TextEncoder();
+
+    const sendResize = () => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+      }
+    };
+
+    ws.onopen = () => {
+      setStatus('connected');
+      sendResize();
+      term.focus();
+    };
+
+    ws.onmessage = (event) => {
+      if (typeof event.data === 'string') {
+        term.write(event.data);
+      } else {
+        term.write(new Uint8Array(event.data));
+      }
+    };
+
+    ws.onclose = (event) => {
+      setStatus('closed');
+      setCloseMessage(CLOSE_MESSAGES[event.code] || 'Connection closed.');
+    };
+
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(encoder.encode(data));
+      }
+    });
+
+    // Legacy binary input (e.g. some mouse protocols): one byte per char code
+    term.onBinary((data) => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      const bytes = new Uint8Array(data.length);
+      for (let i = 0; i < data.length; i += 1) {
+        bytes[i] = data.charCodeAt(i) & 0xff;
+      }
+      ws.send(bytes);
+    });
+
+    term.onResize(sendResize);
+
+    // Refit on layout changes; fit() fires term.onResize -> server resize_pty
+    const resizeObserver = new ResizeObserver(() => fitAddon.fit());
+    resizeObserver.observe(node);
+
+    return () => {
+      resizeObserver.disconnect();
+      // Silence callbacks during deliberate teardown so nothing touches the
+      // disposed terminal or flashes the "closed" overlay.
+      ws.onclose = null;
+      ws.onmessage = null;
+      ws.close();
+      term.dispose();
+    };
+  }, [challengeId, session]);
+
+  return (
+    <div className="relative">
+      <div ref={containerRef} className="h-96 w-full overflow-hidden rounded-lg bg-[#1a1b26] p-2" />
+      {status !== 'connected' && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-black/70 text-white">
+          {status === 'connecting' ? (
+            <p>Connecting to challenge…</p>
+          ) : (
+            <>
+              <p className="mb-3 px-4 text-center">{closeMessage}</p>
+              <button
+                type="button"
+                onClick={() => setSession((n) => n + 1)}
+                className="rounded bg-blue-500 px-4 py-2 transition-colors hover:bg-blue-600"
+              >
+                Reconnect
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ChallengeTerminal.propTypes = {
+  challengeId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+export default ChallengeTerminal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -128,3 +128,11 @@ p, span, button {
 .markdown-content input[type="checkbox"] {
   margin-right: 0.5rem;
 }
+
+/* xterm.js terminal: the global `p, span, button { text-gray-900 }` rule above
+   would otherwise paint the terminal's text spans near-black on the dark
+   background. Let them inherit xterm's theme foreground instead; ANSI-coloured
+   runs keep their inline color (inline styles beat this rule). */
+.xterm .xterm-rows span {
+  color: inherit;
+}

--- a/frontend/src/pages/ChallengeDetail.jsx
+++ b/frontend/src/pages/ChallengeDetail.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
-import { getChallengeById_Team, startChallenge, submitFlag, purchaseHint } from '../api/challenges';
+import { getChallengeById_Team, startChallenge, stopChallenge, submitFlag, purchaseHint } from '../api/challenges';
 import LoadingSpinner from '../components/LoadingSpinner';
+import ChallengeTerminal from '../components/ChallengeTerminal';
 import { useTheme } from '../context/ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
@@ -14,11 +15,12 @@ function ChallengeDetail() {
   const navigate = useNavigate();
   const {isDarkMode}=useTheme();
   const [challenge, setChallenge] = useState(null);
-  const [sshDetails, setSshDetails] = useState(null);
+  const [containerInfo, setContainerInfo] = useState(null);
   const [flag, setFlag] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [challengeStarted, setChallengeStarted] = useState(false);
+  const [stopInProgress, setStopInProgress] = useState(false);
   const [purchaseInProgress, setPurchaseInProgress] = useState(false);
   const [remainingPoints, setRemainingPoints] = useState(null);
 
@@ -68,12 +70,28 @@ function ChallengeDetail() {
   const handleStartChallenge = async () => {
     try {
       const details = await startChallenge(challengeId);
-      setSshDetails(details);
+      setContainerInfo(details);
       setChallengeStarted(true);
       setError(null);
     } catch (error) {
       console.error('Error starting challenge:', error);
-      setError('Failed to start challenge');
+      setError(error.response?.data?.error || 'Failed to start challenge');
+    }
+  };
+
+  const handleStopChallenge = async () => {
+    if (stopInProgress) return;
+    try {
+      setStopInProgress(true);
+      await stopChallenge(challengeId);
+      setContainerInfo(null);
+      setChallengeStarted(false);
+      setError(null);
+    } catch (error) {
+      console.error('Error stopping challenge:', error);
+      setError(error.response?.data?.error || 'Failed to stop challenge');
+    } finally {
+      setStopInProgress(false);
     }
   };
 
@@ -189,14 +207,31 @@ function ChallengeDetail() {
                   Start Docker Challenge
                 </button>
               ) : (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h4 className="text-lg font-semibold text-neutral-800 mb-2">SSH Connection Details:</h4>
-                  <div className="space-y-1 text-neutral-700">
-                    <p>Host: {sshDetails?.host}</p>
-                    <p>Port: {sshDetails?.port}</p>
-                    <p>Username: {sshDetails?.ssh_user}</p>
-                    <p>Password: {sshDetails?.ssh_password}</p>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-lg font-semibold text-neutral-800">
+                      {containerInfo?.terminal ? 'Challenge Terminal' : 'Connection Details'}
+                    </h4>
+                    <button
+                      onClick={handleStopChallenge}
+                      disabled={stopInProgress}
+                      className={`px-3 py-1.5 text-sm text-white rounded transition-colors ${
+                        stopInProgress ? 'bg-gray-400' : 'bg-red-500 hover:bg-red-600'
+                      }`}
+                    >
+                      {stopInProgress ? 'Stopping…' : 'Stop Challenge'}
+                    </button>
                   </div>
+                  {containerInfo?.terminal ? (
+                    <ChallengeTerminal challengeId={challengeId} />
+                  ) : (
+                    <div className="bg-gray-50 rounded-lg p-4">
+                      <div className="space-y-1 text-neutral-700">
+                        <p>Host: {containerInfo?.host}</p>
+                        <p>Port: {containerInfo?.port}</p>
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/admin/ChallengeDetail.jsx
+++ b/frontend/src/pages/admin/ChallengeDetail.jsx
@@ -182,6 +182,7 @@ function EditChallengeModal({ challenge, onClose, onSave }) {
               <input
                 type="file"
                 id="docker-image-upload"
+                name="docker_image"
                 accept=".tar,.tar.gz"
                 onChange={handleChange}
                 className="hidden"

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -6,14 +6,14 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        'mario': ['SuperMario256', 'sans-serif'],
+        mario: ["SuperMario256", "sans-serif"],
       },
       backgroundImage: {
-        'grid-pattern': `linear-gradient(90deg, #80808033 1px, transparent 0), 
-                        linear-gradient(180deg, #80808033 1px, transparent 0)`
+        "grid-pattern": `linear-gradient(90deg, #80808033 1px, transparent 0), 
+                        linear-gradient(180deg, #80808033 1px, transparent 0)`,
       },
       backgroundSize: {
-        'grid': '24px 24px',
+        grid: "24px 24px",
       },
     },
   },


### PR DESCRIPTION
## Summary

Two related pieces of work on challenge orchestration:

1. **Fixes for #34** — the admin challenge form could not upload a Docker image (`.tar`) or set a custom SSH user. The multipart upload path and runtime user handling are fixed, and the container start/stop lifecycle is hardened.
2. **In-browser terminal** — players get an interactive shell into challenge containers directly in the browser, replacing exposed host SSH ports.

Closes #34.

## In-browser terminal

A browser WebSocket (xterm.js) is proxied to a `docker exec` session inside the challenge container over the Docker Engine API.

- **No SSH** — challenge images no longer run `sshd`; the shell is delivered via `docker exec`.
- **No exposed ports** — terminal challenges run on an internal (`internal: true`, no-internet) docker network with nothing published on the host.
- **Unprivileged** — exec runs as a non-root user (`docker exec --user`), so flag file permissions still hold.
- **ASGI** — Django Channels + Daphne serve WebSocket alongside HTTP; the JWT is passed as a query param and validated in ASGI middleware.
- **Wire protocol** — binary frames carry raw terminal bytes, text frames carry JSON control messages (resize). Blocking docker-socket I/O runs in a bounded thread pool that caps concurrent sessions.

Challenge type is decided safely: a challenge is a published-port *service* only when it explicitly declares a port **and** has no shell user; otherwise it is a terminal challenge (exec user defaults to `atlas`). A half-configured challenge gets a working terminal instead of a dead, exposed port.

## Key changes

**Backend**
- `consumers.py` — `TerminalConsumer` bridging WebSocket ↔ `docker exec`
- `ws_auth.py` — query-param JWT middleware; `routing.py` / `asgi.py` — Channels wiring
- `docker_plugin.py` — `start_exec` / `resize_exec` helpers; network attach / optional port publish
- `views.py` — terminal-vs-service gating and start/stop lifecycle hardening
- `requirements.txt` — channels, daphne; `Dockerfile` — serve via daphne

**Frontend**
- `ChallengeTerminal.jsx` — xterm.js terminal, wired into `ChallengeDetail.jsx`
- Build fixes — Node 22 base image, pinned pnpm, `.dockerignore` files

**Challenge image**
- `challenge.Dockerfile` / `challenge.sh` — removed openssh; container stays alive for exec

**Infra**
- internal `challenge-net` in compose; `CHALLENGE_NETWORK` setting/env

## Testing

- docker-exec terminal verified end-to-end: shell I/O round-trips, runs as `atlas`, flag readable, resize works
- gating truth table + real starts verified (terminal vs published-port)
- `manage.py check` clean; frontend build passes; both compose files validate
